### PR TITLE
[Coroutines] MainDispatcherFactory implementation for Paper

### DIFF
--- a/paper/src/main/kotlin/io/github/_4drian3d/mckotlin/paper/PaperMainDispatcherFactory.kt
+++ b/paper/src/main/kotlin/io/github/_4drian3d/mckotlin/paper/PaperMainDispatcherFactory.kt
@@ -1,0 +1,51 @@
+@file:OptIn(InternalCoroutinesApi::class)
+
+package io.github._4drian3d.mckotlin.paper
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.internal.MainDispatcherFactory
+import org.bukkit.Bukkit
+import kotlin.coroutines.CoroutineContext
+import kotlin.math.ceil
+
+class PaperMainDispatcherFactory : MainDispatcherFactory {
+
+    override val loadPriority: Int
+        get() = Int.MAX_VALUE / 2
+
+    override fun createDispatcher(allFactories: List<MainDispatcherFactory>): MainCoroutineDispatcher {
+        return BukkitSchedulerDispatcher()
+    }
+}
+
+private val plugin by lazy {
+    Bukkit.getPluginManager().getPlugin("MCKotlin-Paper")!!
+}
+
+class BukkitSchedulerDispatcher : MainCoroutineDispatcher(), Delay {
+    override val immediate: MainCoroutineDispatcher = this
+
+    override fun dispatch(context: CoroutineContext, block: Runnable) {
+        Bukkit.getScheduler().runTask(
+            plugin,
+            Runnable { block.run() }
+        )
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override fun scheduleResumeAfterDelay(timeMillis: Long, continuation: CancellableContinuation<Unit>) {
+        Bukkit.getScheduler().runTaskLater(
+            plugin,
+            Runnable {
+                with(continuation) { resumeUndispatched(Unit) }
+            },
+            timeMillis.millisToTicks()
+        )
+    }
+
+    private fun Long.millisToTicks(): Long =
+        // One Minecraft tick is 50ms,
+        // so if millis is not divisible without a remainder,
+        // we use the ceiling function to find the next possible tick for execution.
+        ceil(this / 50.0).toLong()
+}

--- a/paper/src/main/kotlin/io/github/_4drian3d/mckotlin/paper/PaperMainDispatcherFactory.kt
+++ b/paper/src/main/kotlin/io/github/_4drian3d/mckotlin/paper/PaperMainDispatcherFactory.kt
@@ -13,9 +13,8 @@ class PaperMainDispatcherFactory : MainDispatcherFactory {
     override val loadPriority: Int
         get() = Int.MAX_VALUE / 2
 
-    override fun createDispatcher(allFactories: List<MainDispatcherFactory>): MainCoroutineDispatcher {
-        return BukkitSchedulerDispatcher()
-    }
+    override fun createDispatcher(allFactories: List<MainDispatcherFactory>): MainCoroutineDispatcher =
+        BukkitSchedulerDispatcher()
 }
 
 private val plugin by lazy {
@@ -23,6 +22,7 @@ private val plugin by lazy {
 }
 
 class BukkitSchedulerDispatcher : MainCoroutineDispatcher(), Delay {
+
     override val immediate: MainCoroutineDispatcher = this
 
     override fun dispatch(context: CoroutineContext, block: Runnable) {

--- a/paper/src/main/resources/META-INF/services/kotlinx.coroutines.internal.MainDispatcherFactory
+++ b/paper/src/main/resources/META-INF/services/kotlinx.coroutines.internal.MainDispatcherFactory
@@ -1,0 +1,1 @@
+io.github._4drian3d.mckotlin.paper.PaperMainDispatcherFactory


### PR DESCRIPTION
Implementation for [Main Dispatcher](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-dispatchers/-main.html) that works on the Minecraft server thread using `BukkitScheduler#runTask`.

This allows to use `Dispatchers.Main` like this:
```kotlin
CoroutineScope(Dispatchers.Default).launch {
    val result = withContext(Dispatchers.Main) {
        // result from Minecraft server main thread
        ""
    }

    // use result from main thread
    // ...
}
```